### PR TITLE
Refactor pending keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.1.5
+
+* [PR #8] - Refactor how pending keys are handled [Scott Sanders]
+
 ## v0.1.4
 
 * [PR #6] - Update to tarsnap v1.0.34 [Greg Fitzgerald]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,6 +41,7 @@ default['tarsnap']['feather']['max_runtime'] = "3600"
 default['tarsnap']['feather']['repo_url'] = "git://github.com/danrue/feather.git"
 default['tarsnap']['feather']['repo_rev'] = "master"
 default['tarsnap']['feather']['key_path'] = "/root"
+default['tarsnap']['feather']['bin_path'] = "/usr/local/bin/feather"
 
 case node['platform']
 when "freebsd"

--- a/knife-tarsnap/lib/chef/knife/tarsnap/core.rb
+++ b/knife-tarsnap/lib/chef/knife/tarsnap/core.rb
@@ -98,8 +98,9 @@ class Chef
 
         # Return the list of nodes from the data bag marked as pending.
         def pending_nodes
+          Shell::Extensions.extend_context_object(self)
           @_pending_nodes || @_pending_nodes =
-            Chef::DataBag.load(tarsnap_data_bag).keep_if{|k,v| k =~ /^__/}.map{|k,v| k.gsub(/^__/, '').gsub("_",".")}
+            nodes.find('tarsnap_pending:true').map{|n| n.fqdn}
         end
 
         # Return the list of nodes from the data bag marked as having keys.
@@ -131,7 +132,9 @@ class Chef
 
         # Remove the data bag entry for a pending node.
         def remove_pending_node(fqdn)
-          rest.delete_rest("data/#{tarsnap_data_bag}/__#{canonicalize(fqdn)}")
+          n = nodes.find("fqdn:#{fqdn}").first
+          n.set.delete('tarsnap_pending')
+          n.save
         end
 
         private

--- a/knife-tarsnap/lib/knife-tarsnap/version.rb
+++ b/knife-tarsnap/lib/knife-tarsnap/version.rb
@@ -1,5 +1,5 @@
 module Knife
   module Tarsnap
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "ssanders@taximagic.com"
 license          "Apache 2.0"
 description      "Knife plugin and Chef cookbook for managing tarsnap."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.4"
+version          "0.1.5"
 
 %w{freebsd ubuntu debian}.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,9 +21,7 @@ end
 
 # Ensure the data bag for keys is created
 unless Chef::DataBag.list.key?(node['tarsnap']['data_bag'])
-  new_databag = Chef::DataBag.new
-  new_databag.name(node['tarsnap']['data_bag'])
-  new_databag.save
+  Chef::Log.warn("You must create the keys data bag (#{node['tarsnap']['data_bag']}) first!")
 end
 
 # Install tarsnap


### PR DESCRIPTION
This refactors the "pending keys" notifications that is visible through `knife tarsnap key list` to use node attributes instead of data bag items. By removing the dependance on data bags, the nodes do not require elevated privileges. 

This resolves issue #3.
